### PR TITLE
移除 `item !== CORTEX_JSON_CONFIG.name` 的逻辑

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,44 @@
 # cortex-recombiner
+
 recombine the cortex package structure to make it compatible with webpack
 
-####How to use (ver 1.x and 2.x) sync mode
+#### How to use (ver 1.x and 2.x) sync mode
 
-````
-var recombiner=require('cortex-recombiner');
+```js
+var recombiner = require('cortex-recombiner');
 
-...
+// ...
 
 recombiner({
-        base:__dirname，	//the base dir path of webpack project
-        source_path:'./neurons',	//the relative path of neurons source dir
-    	target_path:'./node_modules/@cortex',	//the relative path of target dir where you want to recombine
-    	cortex_json_file:'./cortex.json',	//the path of cortex config file
-    	noBeta:false	//whether ignore cortex beta package in source_path
+    base: __dirname,                        // the base dir path of webpack project
+    source_path: './neurons',               // the relative path of neurons source dir
+    target_path: './node_modules/@cortex',  // the relative path of target dir where you want to recombine
+    cortex_json_file: './cortex.json',      // the path of cortex config file
+    noBeta: false                           // whether ignore cortex beta package in source_path
 });
 
-...
+// ...
+```
 
-````
+#### How to use (ver 3.x) async mode
 
-####How to use (ver 3.x) async mode
+```js
+var recombiner = require('cortex-recombiner');
 
-````
-var recombiner=require('cortex-recombiner');
+// ...
 
-...
-
-//return a promise
+// return a promise
 recombiner({
-        base:__dirname，	//the base dir path of webpack project
-        source_path:'./neurons',	//the relative path of neurons source dir
-    	target_path:'./node_modules/@cortex',	//the relative path of target dir where you want to recombine
-    	cortex_json_file:'./cortex.json',	//the path of cortex config file
-    	noBeta:false	//whether ignore cortex beta package in source_path
+    base: __dirname,                        // the base dir path of webpack project
+    source_path: './neurons',               // the relative path of neurons source dir
+    target_path: './node_modules/@cortex',  // the relative path of target dir where you want to recombine
+    cortex_json_file: './cortex.json',      // the path of cortex config file
+    noBeta: false                           // whether ignore cortex beta package in source_path
 }).then(function(result) {
-    ...
+    // ...
 },function(error) {
-    ...
+    // ...
 });
 
-...
-
-````
+// ...
+```

--- a/lib/index.js
+++ b/lib/index.js
@@ -65,7 +65,11 @@ const TASK={
             }
             yield files&&_.map(files,function (item) {
                 return function* () {
-                    if (fs.statSync(path.join(OPTIONS.source_path,item)).isDirectory() && item != 'neuron' && item != CORTEX_JSON_CONFIG.name) {
+                    /**
+                     * 移除 `item !== CORTEX_JSON_CONFIG.name` 的逻辑，兼容下面的使用场景：
+                     *  - 在 cortex 项目中使用 npm 进行测试，需要将包自身也做转换，完全通过 npm 库完成测试。
+                     */
+                    if (fs.statSync(path.join(OPTIONS.source_path,item)).isDirectory() && item != 'neuron') {
                         CORTEX_PACKAGES[item]={};
                     }
                 }


### PR DESCRIPTION
移除 `item !== CORTEX_JSON_CONFIG.name` 的逻辑，兼容下面的使用场景：
 - 在 cortex 项目中使用 npm 进行测试，需要将包自身也做转换，完全通过 npm 库完成测试。
